### PR TITLE
This PR adds support for CakePHP 5.x.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4']
+        php-version: ['8.1']
         db-type: [mysql]
     name: PHP ${{ matrix.php-version }}
 
@@ -38,11 +38,7 @@ jobs:
 
       - name: composer install
         run: |
-          if [[ ${{ matrix.php-version }} == '8.0' ]]; then
-            composer install --ignore-platform-reqs
-          else
-            composer install
-          fi
+          composer install
 
       - name: Run PHPUnit
         run: |
@@ -60,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl
           coverage: none
 
@@ -82,11 +78,11 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: none
 
       - name: composer install
-        run: composer install
+        run: composer require --dev phpstan/phpstan:^1.9
 
       - name: Run phpstan
         run: vendor/bin/phpstan.phar analyse

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.lock
 /phpunit.xml
+/.phpunit.cache
 /.phpunit.result.cache
 /phpunit.phar
 /config/Migrations/schema-dump-default.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CharacterPagination plugin for CakePHP
 
+## Version map:
+| Plugin | Branch | Cake | PHP |
+|--------| ------ | --- | --- |
+| 2.x    | main | 5.x | ^8.1 |
+| 1.x    | 1.x | 4.x | ^7.4 \| ^8.0 |
+
 ## Installation
 
 You can install this plugin into your CakePHP application using [composer](https://getcomposer.org).

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "cakephp/cakephp": "^5.x-dev"
+        "cakephp/cakephp": "^5.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.1.0",
@@ -41,7 +41,7 @@
         "test": "phpunit --colors=always"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.4",
-        "cakephp/cakephp": "^4.2"
+        "php": "^8.1",
+        "cakephp/cakephp": "^5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
-        "cakephp/cakephp-codesniffer": "^4.2",
+        "phpunit/phpunit": "^9.5",
+        "cakephp/cakephp-codesniffer": "^5.0",
         "phpstan/phpstan": "^1.9"
     },
     "autoload": {
@@ -40,6 +40,8 @@
         "stan": "phpstan analyze",
         "test": "phpunit --colors=always"
     },
+    "prefer-stable": true,
+    "minimum-stability": "dev",
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "cakephp/cakephp": "^5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.1.0",
         "cakephp/cakephp-codesniffer": "^5.0",
         "phpstan/phpstan": "^1.9"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,3 @@ parameters:
         -
             message: '#Access to an undefined property Cake\\View\\View::\$Character.#'
             path: src/View/Cell/CharacterCell.php
-        -
-            message: '#Else branch is unreachable because previous condition is always true.#'
-            path: src/Traits/RepositoryTrait.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,27 +9,13 @@
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
     </php>
-
     <!-- Add any additional test suites you want to run here -->
     <testsuites>
         <testsuite name="Letter Pagination Test suite">
             <directory>./tests/TestCase</directory>
         </testsuite>
     </testsuites>
-
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener class="Cake\TestSuite\Fixture\FixtureInjector">
-            <arguments>
-                <object class="Cake\TestSuite\Fixture\FixtureManager"/>
-            </arguments>
-        </listener>
-    </listeners>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="tests/bootstrap.php"
-    >
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+    cacheDirectory=".phpunit.cache"
+>
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
@@ -16,6 +19,6 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+        <bootstrap class="Cake\TestSuite\Fixture\Extension\PHPUnitExtension"/>
     </extensions>
 </phpunit>

--- a/src/Controller/Component/CharacterComponent.php
+++ b/src/Controller/Component/CharacterComponent.php
@@ -7,6 +7,10 @@ use Avolle\CharacterPagination\Traits\RepositoryTrait;
 use Cake\Controller\Component;
 use Cake\Datasource\ResultSetInterface;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
 use Cake\View\CellTrait;
 
 /**
@@ -23,14 +27,14 @@ class CharacterComponent extends Component
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Components to use in this Component
      *
-     * @var string[]
+     * @var array
      */
-    protected $components = [
+    protected array $components = [
         'Paginator',
     ];
 
@@ -39,14 +43,14 @@ class CharacterComponent extends Component
      *
      * @var \Cake\Http\ServerRequest
      */
-    protected $request;
+    protected ServerRequest $request;
 
     /**
      * Response
      *
      * @var \Cake\Http\Response
      */
-    protected $response;
+    protected Response $response;
 
     /**
      * Paginate the results after filtering the records that start with the requested character.

--- a/src/Controller/Component/CharacterComponent.php
+++ b/src/Controller/Component/CharacterComponent.php
@@ -70,7 +70,7 @@ class CharacterComponent extends Component
 
         $requestCharacters = $this->getRequestCharacters();
         if (!empty($requestCharacters)) {
-            $this->query = $this->query->find('recordsWithCharacters', ['characters' => $requestCharacters]);
+            $this->query = $this->query->find('recordsWithCharacters', characters: $requestCharacters);
         }
 
         return $this->getController()->paginate($this->query, $settings);

--- a/src/Controller/Component/CharacterComponent.php
+++ b/src/Controller/Component/CharacterComponent.php
@@ -5,7 +5,7 @@ namespace Avolle\CharacterPagination\Controller\Component;
 
 use Avolle\CharacterPagination\Traits\RepositoryTrait;
 use Cake\Controller\Component;
-use Cake\Datasource\ResultSetInterface;
+use Cake\Datasource\Paging\PaginatedInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -55,12 +55,11 @@ class CharacterComponent extends Component
     /**
      * Paginate the results after filtering the records that start with the requested character.
      *
-     * @param \Cake\ORM\Table|\Cake\ORM\Query $object Object to filter and paginate
+     * @param \Cake\ORM\Table|\Cake\ORM\Query\SelectQuery $object Object to filter and paginate
      * @param array $settings Pagination settings
-     * @return \Cake\Datasource\ResultSetInterface
-     * @throws \Exception
+     * @return \Cake\Datasource\Paging\PaginatedInterface
      */
-    public function paginate($object, $settings = []): ResultSetInterface
+    public function paginate(Table|SelectQuery $object, array $settings = []): PaginatedInterface
     {
         $this->determineRepository($object);
         if (!$this->repository->hasBehavior('Character')) {
@@ -92,11 +91,11 @@ class CharacterComponent extends Component
     /**
      * Create a Character cell
      *
-     * @param \Cake\ORM\Table|\Cake\ORM\Query $object Table or Query instance passed to cell
+     * @param \Cake\ORM\Table|\Cake\ORM\Query\SelectQuery $object Table or Query instance passed to cell
      * @return void
      * @uses \Avolle\CharacterPagination\View\Cell\CharacterCell
      */
-    protected function createCell($object): void
+    protected function createCell(Table|SelectQuery $object): void
     {
         $characterCell = $this->cell('Avolle/CharacterPagination.Character', [$object]);
         $this->getController()->viewBuilder()->setVar('characterCell', $characterCell);

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -21,7 +21,7 @@ class CharacterBehavior extends Behavior
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'field' => null,
         'cacheKey' => null,
     ];

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -42,19 +42,16 @@ class CharacterBehavior extends Behavior
     }
 
     /**
-     * Get all records matching the selected `characters` option
+     * Get all records matching the selected `characters` argument.
      * Filtering is used by leveraging the REGEXP sql function, filtering records starting by either characters provided
      *
      * @param \Cake\ORM\Query\SelectQuery $query Query
-     * @param array $options Options
+     * @param array<string> $characters Characters to find records starting with
      * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findRecordsWithCharacters(SelectQuery $query, array $options): SelectQuery
+    public function findRecordsWithCharacters(SelectQuery $query, array $characters = ['A']): SelectQuery
     {
-        if (!isset($options['characters']) || !is_array($options['characters'])) {
-            $options['characters'] = ['A'];
-        }
-        $charactersString = implode('|', $options['characters']);
+        $charactersString = implode('|', $characters);
         $cond = sprintf("%s REGEXP '^(%s)'", $this->determineField(), $charactersString);
 
         return $query->where($cond)->orderByAsc($this->determineField());

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -5,7 +5,7 @@ namespace Avolle\CharacterPagination\Model\Behavior;
 
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Behavior;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 
 /**
  * Class CharacterBehavior
@@ -29,27 +29,27 @@ class CharacterBehavior extends Behavior
     /**
      * Find all used first characters with the configured field in table
      *
-     * @param \Cake\ORM\Query $query Query
-     * @return \Cake\ORM\Query
+     * @param \Cake\ORM\Query\SelectQuery $query Query
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findCharacters(Query $query): Query
+    public function findCharacters(SelectQuery $query): SelectQuery
     {
         $nameIdentifier = new IdentifierExpression($this->determineField());
         $firstChar = $query->func()
             ->aggregate('LEFT', [$nameIdentifier, 1], [], 'string');
 
-        return $query->select(compact('firstChar'))->group('firstChar')->orderAsc('firstChar');
+        return $query->select(compact('firstChar'))->groupBy('firstChar')->orderByAsc('firstChar');
     }
 
     /**
      * Get all records matching the selected `characters` option
      * Filtering is used by leveraging the REGEXP sql function, filtering records starting by either characters provided
      *
-     * @param \Cake\ORM\Query $query Query
+     * @param \Cake\ORM\Query\SelectQuery $query Query
      * @param array $options Options
-     * @return \Cake\ORM\Query
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findRecordsWithCharacters(Query $query, array $options): Query
+    public function findRecordsWithCharacters(SelectQuery $query, array $options): SelectQuery
     {
         if (!isset($options['characters']) || !is_array($options['characters'])) {
             $options['characters'] = ['A'];
@@ -57,7 +57,7 @@ class CharacterBehavior extends Behavior
         $charactersString = implode('|', $options['characters']);
         $cond = sprintf("%s REGEXP '^(%s)'", $this->determineField(), $charactersString);
 
-        return $query->where($cond)->orderAsc($this->determineField());
+        return $query->where($cond)->orderByAsc($this->determineField());
     }
 
     /**

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -86,7 +86,7 @@ class CharacterBehavior extends Behavior
      * @param \Cake\Database\Expression\FunctionExpression|string $value Value to ASCII
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    protected function ascii($value): FunctionExpression
+    protected function ascii(FunctionExpression|string $value): FunctionExpression
     {
         return new FunctionExpression('ASCII', [$value]);
     }

--- a/src/Traits/RepositoryTrait.php
+++ b/src/Traits/RepositoryTrait.php
@@ -3,16 +3,15 @@ declare(strict_types=1);
 
 namespace Avolle\CharacterPagination\Traits;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
-use InvalidArgumentException;
 
 trait RepositoryTrait
 {
     /**
-     * @var \Cake\ORM\Query
+     * @var \Cake\ORM\Query\SelectQuery
      */
-    protected $query;
+    protected SelectQuery $query;
 
     /**
      * @var \Cake\ORM\Table
@@ -22,31 +21,17 @@ trait RepositoryTrait
     /**
      * Setup `query` and `repositories` properties in class based on which argument is passed to method
      *
-     * @param \Cake\ORM\Table|\Cake\ORM\Query $object Table or Query instance to use loading and filtering characters
+     * @param \Cake\ORM\Table|\Cake\ORM\Query\SelectQuery $object Table or Query instance to use loading and filtering characters
      * @return void
-     * @throws \Exception
      */
-    protected function determineRepository($object): void
+    protected function determineRepository(Table|SelectQuery $object): void
     {
         if ($object instanceof Table) {
             $this->repository = $object;
             $this->query = $object->query();
-        } elseif ($object instanceof Query) {
+        } else {
             $this->repository = $object->getRepository();
             $this->query = $object;
-        } else {
-            if (is_object($object)) {
-                $message = get_class($object);
-            } else {
-                $message = $object;
-            }
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Invalid argument `%s` when creating character pagination. '
-                    . 'Instance of Cake\\ORM\\Table or Cake\\ORM\\Query expected.',
-                    $message
-                )
-            );
         }
     }
 }

--- a/src/Traits/RepositoryTrait.php
+++ b/src/Traits/RepositoryTrait.php
@@ -17,7 +17,7 @@ trait RepositoryTrait
     /**
      * @var \Cake\ORM\Table
      */
-    protected $repository;
+    protected Table $repository;
 
     /**
      * Setup `query` and `repositories` properties in class based on which argument is passed to method

--- a/src/View/Cell/CharacterCell.php
+++ b/src/View/Cell/CharacterCell.php
@@ -20,9 +20,9 @@ class CharacterCell extends Cell
      * List of valid options that can be passed into this
      * cell's constructor.
      *
-     * @var string[]
+     * @var array<string>
      */
-    protected $_validCellOptions = [];
+    protected array $_validCellOptions = [];
 
     /**
      * Initialization logic run at the end of object construction.

--- a/src/View/Cell/CharacterCell.php
+++ b/src/View/Cell/CharacterCell.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace Avolle\CharacterPagination\View\Cell;
 
 use Avolle\CharacterPagination\Traits\RepositoryTrait;
-use Cake\Datasource\QueryInterface;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
 use Cake\View\Cell;
 
 /**
@@ -40,13 +41,12 @@ class CharacterCell extends Cell
     /**
      * Default display method.
      *
-     * @param \Cake\ORM\Table|\Cake\ORM\Query $object Model class to load character records from
+     * @param \Cake\ORM\Table|\Cake\ORM\Query\SelectQuery $object Model class to load character records from
      * @return void
-     * @throws \Exception
      */
-    public function display($object): void
+    public function display(Table|SelectQuery $object): void
     {
-        $characters = $this->getCharacters($object);
+        $characters = $this->getCharacters($object)->all();
         $links = [];
         foreach ($characters->toArray() as $character) {
             /** @noinspection PhpUndefinedFieldInspection */
@@ -60,11 +60,10 @@ class CharacterCell extends Cell
      * Will check if CharacterBehavior exists in model. If not, add it.
      * Then find characters from the behavior finder
      *
-     * @param \Cake\ORM\Table|\Cake\ORM\Query $object Model class to get character records from
-     * @return \Cake\Datasource\QueryInterface
-     * @throws \Exception
+     * @param \Cake\ORM\Table|\Cake\ORM\Query\SelectQuery $object Model class to get character records from
+     * @return \Cake\ORM\Query\SelectQuery
      */
-    protected function getCharacters($object): QueryInterface
+    protected function getCharacters(Table|SelectQuery $object): SelectQuery
     {
         $this->determineRepository($object);
         if (!$this->repository->hasBehavior('Character')) {

--- a/src/View/Helper/CharacterHelper.php
+++ b/src/View/Helper/CharacterHelper.php
@@ -17,16 +17,16 @@ class CharacterHelper extends Helper
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'activeClassName' => 'active',
     ];
 
     /**
      * Helpers
      *
-     * @var string[]
+     * @var array
      */
-    protected $helpers = [
+    protected array $helpers = [
         'Html',
     ];
 

--- a/tests/Fixture/MoviesFixture.php
+++ b/tests/Fixture/MoviesFixture.php
@@ -9,27 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class MoviesFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'title' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'link' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'release_date' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'latin1_swedish_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Init method
      *
      * @return void

--- a/tests/Fixture/MoviesFixture.php
+++ b/tests/Fixture/MoviesFixture.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Avolle\CharacterPagination\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/MoviesFixture.php
+++ b/tests/Fixture/MoviesFixture.php
@@ -1,7 +1,6 @@
 <?php
 namespace Avolle\CharacterPagination\Test\Fixture;
 
-use Cake\I18n\FrozenDate;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
@@ -42,25 +41,21 @@ class MoviesFixture extends TestFixture
                 'id' => 1,
                 'title' => 'Shawshank Redemption',
                 'link' => 'https://imdb.com/shawshank-redemption',
-                'release_date' => new FrozenDate('1995-01-06'),
             ],
             [
                 'id' => 2,
                 'title' => 'The Green Mile',
                 'link' => 'https://imdb.com/the-green-mile',
-                'release_date' => new FrozenDate('2000-02-11'),
             ],
             [
                 'id' => 3,
                 'title' => 'Gone in Sixty Seconds',
                 'link' => 'https://imdb.com/gone-in-sixty-seconds',
-                'release_date' => new FrozenDate('2000-06-09'),
             ],
             [
                 'id' => 4,
                 'title' => 'American History X',
                 'link' => 'https://imdb.com/american-history-x',
-                'release_date' => new FrozenDate('1999-02-12'),
             ],
         ];
         parent::init();

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -9,30 +9,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class UsersFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 40, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'email' => ['type' => 'string', 'length' => 50, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'number' => ['type' => 'string', 'length' => 20, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'password' => ['type' => 'string', 'length' => 70, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'role' => ['type' => 'tinyinteger', 'length' => 4, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-            'email' => ['type' => 'unique', 'columns' => ['email'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'latin1_swedish_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Init method
      *
      * @return void

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -44,33 +44,21 @@ class UsersFixture extends TestFixture
                 'id' => 1,
                 'name' => 'A User Name',
                 'email' => 'some.user@users.com',
-                'number' => '+4799999999',
-                'password' => '$2y$10$5fTuNphejvCQGth5jTIEFuWzYN646DWsSEXA6VfMitkeLVba4Dzwa', //Lorem ipsum dolor sit amet
-                'role' => 0,
             ],
             [
                 'id' => 2,
                 'name' => 'B User Name 2',
                 'email' => 'Xsome.other.user@users.com',
-                'number' => '+4798888888',
-                'password' => '$2y$10$5fTuNphejvCQGth5jTIEFuWzYN646DWsSEXA6VfMitkeLVba4Dzwa', //Lorem ipsum dolor sit amet
-                'role' => 2,
             ],
             [
                 'id' => 3,
                 'name' => 'A User Name 3',
                 'email' => 'Xsome.other.other.user@users.com',
-                'number' => '+4797777777',
-                'password' => '$2y$10$5fTuNphejvCQGth5jTIEFuWzYN646DWsSEXA6VfMitkeLVba4Dzwa', //Lorem ipsum dolor sit amet
-                'role' => 0,
             ],
             [
                 'id' => 4,
                 'name' => 'K User Name 4',
                 'email' => 'Ksome.other.other.other.user@users.com',
-                'number' => '+4796666666',
-                'password' => '$2y$10$5fTuNphejvCQGth5jTIEFuWzYN646DWsSEXA6VfMitkeLVba4Dzwa', //Lorem ipsum dolor sit amet
-                'role' => 1,
             ],
         ];
         parent::init();

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Avolle\CharacterPagination\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/TestCase/Controller/Component/CharacterComponentTest.php
+++ b/tests/TestCase/Controller/Component/CharacterComponentTest.php
@@ -67,12 +67,13 @@ class CharacterComponentTest extends TestCase
      */
     public function testPaginateQueryObject(): void
     {
+        /** @var \Cake\Datasource\Paging\PaginatedResultSet $users */
         $users = $this->Character->paginate((new UsersTable())->find());
         $expected = [
             'A User Name',
             'A User Name 3',
         ];
-        $this->assertSame($expected, $users->extract('name')->toArray());
+        $this->assertSame($expected, $users->items()->extract('name')->toArray());
     }
 
     /**
@@ -85,12 +86,13 @@ class CharacterComponentTest extends TestCase
      */
     public function testPaginateTableObject(): void
     {
+        /** @var \Cake\Datasource\Paging\PaginatedResultSet $users */
         $users = $this->Character->paginate(new UsersTable());
         $expected = [
             'A User Name',
             'A User Name 3',
         ];
-        $this->assertSame($expected, $users->extract('name')->toArray());
+        $this->assertSame($expected, $users->items()->extract('name')->toArray());
     }
 
     /**

--- a/tests/TestCase/Controller/Component/CharacterComponentTest.php
+++ b/tests/TestCase/Controller/Component/CharacterComponentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Avolle\CharacterPagination\Test\TestCase\Controller\Component;
 
 use Avolle\CharacterPagination\Controller\Component\CharacterComponent;
+use Avolle\CharacterPagination\View\Cell\CharacterCell;
 use Cake\Controller\ComponentRegistry;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -16,7 +17,7 @@ use TestApp\Model\Table\UsersTable;
  */
 class CharacterComponentTest extends TestCase
 {
-    protected $fixtures = [
+    protected array $fixtures = [
         'plugin.Avolle/CharacterPagination.Movies',
         'plugin.Avolle/CharacterPagination.Users',
     ];
@@ -26,7 +27,7 @@ class CharacterComponentTest extends TestCase
      *
      * @var \Avolle\CharacterPagination\Controller\Component\CharacterComponent
      */
-    protected $Character;
+    protected CharacterComponent $Character;
 
     /**
      * setUp method
@@ -120,6 +121,6 @@ class CharacterComponentTest extends TestCase
     {
         $this->Character->paginate(new MoviesTable());
         $cell = $this->Character->getController()->viewBuilder()->getVar('characterCell');
-        $this->assertInstanceOf('Avolle\\CharacterPagination\\View\\Cell\\CharacterCell', $cell);
+        $this->assertInstanceOf(CharacterCell::class, $cell);
     }
 }

--- a/tests/TestCase/Controller/Component/CharacterComponentTest.php
+++ b/tests/TestCase/Controller/Component/CharacterComponentTest.php
@@ -5,6 +5,7 @@ namespace Avolle\CharacterPagination\Test\TestCase\Controller\Component;
 
 use Avolle\CharacterPagination\Controller\Component\CharacterComponent;
 use Avolle\CharacterPagination\View\Cell\CharacterCell;
+use Cake\Collection\Collection;
 use Cake\Controller\ComponentRegistry;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -92,7 +93,7 @@ class CharacterComponentTest extends TestCase
             'A User Name',
             'A User Name 3',
         ];
-        $this->assertSame($expected, $users->items()->extract('name')->toArray());
+        $this->assertSame($expected, (new Collection($users->items()))->extract('name')->toArray());
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -28,7 +28,7 @@ class CharacterBehaviorTest extends TestCase
         $usersTable = new UsersTable();
         $actual = $usersTable->find('characters');
 
-        $this->assertSame(['A', 'B', 'K', 'Å'], $actual->extract('firstChar')->toArray());
+        $this->assertSame(['A', 'B', 'K', 'Å'], $actual->all()->extract('firstChar')->toArray());
     }
 
     /**
@@ -118,10 +118,10 @@ class CharacterBehaviorTest extends TestCase
         $expected = [
             'Å user name',
         ];
-        $this->assertEquals($expected, $actual->extract('name')->toArray());
+        $this->assertEquals($expected, $actual->all()->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', characters: ['C', 'D']);
-        $this->assertEmpty($actual->extract('name')->toArray());
+        $this->assertEmpty($actual->all()->extract('name')->toArray());
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -114,13 +114,13 @@ class CharacterBehaviorTest extends TestCase
         $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
         // Foreign letter
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['Å']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['Å']);
         $expected = [
             'Å user name',
         ];
         $this->assertEquals($expected, $actual->extract('name')->toArray());
 
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['C', 'D']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['C', 'D']);
         $this->assertEmpty($actual->extract('name')->toArray());
     }
 

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -28,7 +28,7 @@ class CharacterBehaviorTest extends TestCase
         $usersTable = new UsersTable();
         $actual = $usersTable->find('characters');
 
-        $this->assertSame(['A', 'B', 'K'], $actual->extract('firstChar')->toArray());
+        $this->assertSame(['A', 'B', 'K'], $actual->all()->extract('firstChar')->toArray());
     }
 
     /**
@@ -47,7 +47,7 @@ class CharacterBehaviorTest extends TestCase
             'A User Name',
             'A User Name 3',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
     }
 
     /**
@@ -66,7 +66,7 @@ class CharacterBehaviorTest extends TestCase
             'A User Name',
             'A User Name 3',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
     }
 
     /**
@@ -85,7 +85,7 @@ class CharacterBehaviorTest extends TestCase
             'A User Name',
             'A User Name 3',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
     }
 
     /**
@@ -104,7 +104,7 @@ class CharacterBehaviorTest extends TestCase
             'A User Name 3',
             'B User Name 2',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['B', 'A']]);
         $expected = [
@@ -112,28 +112,28 @@ class CharacterBehaviorTest extends TestCase
             'A User Name 3',
             'B User Name 2',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['B', 'B']]);
         $expected = [
             'B User Name 2',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['B', 'C']]);
         $expected = [
             'B User Name 2',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['J', 'K']]);
         $expected = [
             'K User Name 4',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['C', 'D']]);
-        $this->assertEmpty($actual->extract('name')->toArray());
+        $this->assertEmpty($actual->all()->extract('name')->toArray());
     }
 
     /**
@@ -152,6 +152,6 @@ class CharacterBehaviorTest extends TestCase
             'A User Name 3',
             'B User Name 2',
         ];
-        $this->assertSame($expected, $actual->extract('name')->toArray());
+        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
     }
 }

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -13,7 +13,7 @@ class CharacterBehaviorTest extends TestCase
      *
      * @var string[]
      */
-    protected $fixtures = [
+    protected array $fixtures = [
         'plugin.Avolle/CharacterPagination.Users',
     ];
 

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -52,25 +52,6 @@ class CharacterBehaviorTest extends TestCase
 
     /**
      * Test findRecordsWithCharacters method
-     * `characters` option provided, but is not array - Get records with character `A`
-     *
-     * @return void
-     * @uses \Avolle\CharacterPagination\Model\Behavior\CharacterBehavior::findRecordsWithCharacters()
-     */
-    public function testFindRecordsWithCharactersCharactersOptionsIsNotArray(): void
-    {
-        $usersTable = new UsersTable();
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => 'not-an-array']);
-
-        $expected = [
-            'A User Name',
-            'A User Name 3',
-        ];
-        $this->assertSame($expected, $actual->all()->extract('name')->toArray());
-    }
-
-    /**
-     * Test findRecordsWithCharacters method
      * `characters` option provided, and is only `A` - Get records with character `A`
      *
      * @return void

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -79,7 +79,7 @@ class CharacterBehaviorTest extends TestCase
     public function testFindRecordsWithCharactersCharactersOptionsIsSingleCharacterA(): void
     {
         $usersTable = new UsersTable();
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['A']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['A']);
 
         $expected = [
             'A User Name',
@@ -98,7 +98,7 @@ class CharacterBehaviorTest extends TestCase
     public function testFindRecordsWithCharactersCharactersOptionsIsMultipleCharacters(): void
     {
         $usersTable = new UsersTable();
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['A', 'B']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['A', 'B']);
         $expected = [
             'A User Name',
             'A User Name 3',
@@ -106,7 +106,7 @@ class CharacterBehaviorTest extends TestCase
         ];
         $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['B', 'A']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['B', 'A']);
         $expected = [
             'A User Name',
             'A User Name 3',
@@ -114,25 +114,25 @@ class CharacterBehaviorTest extends TestCase
         ];
         $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['B', 'B']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['B', 'B']);
         $expected = [
             'B User Name 2',
         ];
         $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['B', 'C']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['B', 'C']);
         $expected = [
             'B User Name 2',
         ];
         $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['J', 'K']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['J', 'K']);
         $expected = [
             'K User Name 4',
         ];
         $this->assertSame($expected, $actual->all()->extract('name')->toArray());
 
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['C', 'D']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['C', 'D']);
         $this->assertEmpty($actual->all()->extract('name')->toArray());
     }
 
@@ -147,7 +147,7 @@ class CharacterBehaviorTest extends TestCase
     {
         $usersTable = new UsersTable();
         $usersTable->getBehavior('Character')->setConfig('field', 'email');
-        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['X']]);
+        $actual = $usersTable->find('recordsWithCharacters', characters: ['X']);
         $expected = [
             'A User Name 3',
             'B User Name 2',

--- a/tests/TestCase/Traits/RepositoryTraitTest.php
+++ b/tests/TestCase/Traits/RepositoryTraitTest.php
@@ -3,14 +3,12 @@ declare(strict_types=1);
 
 namespace Avolle\CharacterPagination\Test\TestCase\Traits;
 
-use Avolle\CharacterPagination\Plugin as CharacterPaginationPlugin;
 use Avolle\CharacterPagination\Traits\RepositoryTrait;
-use Cake\Database\Connection;
-use Cake\Datasource\ConnectionManager;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
+use Cake\TestSuite\TestCase;
 use TestApp\Model\Table\UsersTable;
 
-class RepositoryTraitTest extends \Cake\TestSuite\TestCase
+class RepositoryTraitTest extends TestCase
 {
     use RepositoryTrait;
 
@@ -28,13 +26,12 @@ class RepositoryTraitTest extends \Cake\TestSuite\TestCase
      * A Table instance is passed, assert repository and query properties
      *
      * @return void
-     * @throws \Exception
      * @uses \Avolle\CharacterPagination\Traits\RepositoryTrait::determineRepository()
      */
     public function testDetermineRepositoryTableInstancePassed(): void
     {
         $this->determineRepository(new UsersTable());
-        $this->assertInstanceOf(Query::class, $this->query);
+        $this->assertInstanceOf(SelectQuery::class, $this->query);
         $this->assertInstanceOf(UsersTable::class, $this->repository);
     }
 
@@ -43,52 +40,12 @@ class RepositoryTraitTest extends \Cake\TestSuite\TestCase
      * A Query instance is passed, assert repository and query properties
      *
      * @return void
-     * @throws \Exception
      * @uses \Avolle\CharacterPagination\Traits\RepositoryTrait::determineRepository()
      */
     public function testDetermineRepositoryQueryInstancePassed(): void
     {
-        $connection = new Connection(ConnectionManager::get('test')->config());
-        $this->determineRepository(new Query($connection, new UsersTable()));
-        $this->assertInstanceOf(Query::class, $this->query);
+        $this->determineRepository(new SelectQuery(new UsersTable()));
+        $this->assertInstanceOf(SelectQuery::class, $this->query);
         $this->assertInstanceOf(UsersTable::class, $this->repository);
-    }
-
-    /**
-     * Test determineRepository method
-     * Invalid argument passed to method. Is not an object, so exception message will use value.
-     * Assert exception
-     *
-     * @return void
-     * @throws \Exception
-     * @uses \Avolle\CharacterPagination\Traits\RepositoryTrait::determineRepository()
-     * @noinspection PhpParamsInspection
-     */
-    public function testDetermineRepositoryInvalidArgumentPassed(): void
-    {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid argument `random` when creating character pagination. '
-            . 'Instance of Cake\ORM\Table or Cake\ORM\Query expected.');
-        $this->determineRepository('random');
-    }
-
-    /**
-     * Test determineRepository method
-     * Invalid argument passed to method. Is an object, so exception will use object class name.
-     * Assert exception
-     *
-     * @return void
-     * @throws \Exception
-     * @uses \Avolle\CharacterPagination\Traits\RepositoryTrait::determineRepository()
-     * @noinspection PhpParamsInspection
-     */
-    public function testDetermineRepositoryInvalidInstancePassed(): void
-    {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage(
-            'Invalid argument `Avolle\CharacterPagination\Plugin` when creating character pagination. '
-                . 'Instance of Cake\ORM\Table or Cake\ORM\Query expected.'
-        );
-        $this->determineRepository(new CharacterPaginationPlugin());
     }
 }

--- a/tests/TestCase/Traits/RepositoryTraitTest.php
+++ b/tests/TestCase/Traits/RepositoryTraitTest.php
@@ -19,7 +19,7 @@ class RepositoryTraitTest extends \Cake\TestSuite\TestCase
      *
      * @var string[]
      */
-    protected $fixtures = [
+    protected array $fixtures = [
         'plugin.Avolle/CharacterPagination.Users',
     ];
 

--- a/tests/TestCase/View/Cell/CharacterCellTest.php
+++ b/tests/TestCase/View/Cell/CharacterCellTest.php
@@ -66,8 +66,7 @@ class CharacterCellTest extends TestCase
             'args' => [new UsersTable()],
         ]);
 
-        Router::reload();
-        Router::connect('/{controller}/{action}/*');
+        Router::createRouteBuilder('/')->connect('/{controller}/{action}/*');
         Router::setRequest($this->request);
     }
 

--- a/tests/TestCase/View/Cell/CharacterCellTest.php
+++ b/tests/TestCase/View/Cell/CharacterCellTest.php
@@ -6,9 +6,11 @@ namespace Avolle\CharacterPagination\Test\TestCase\View\Cell;
 use Avolle\CharacterPagination\Plugin as CharacterPaginationPlugin;
 use Avolle\CharacterPagination\View\Cell\CharacterCell;
 use Cake\Core\Plugin;
+use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use TestApp\Model\Table\MoviesTable;
 use TestApp\Model\Table\UsersTable;
 
@@ -22,7 +24,7 @@ class CharacterCellTest extends TestCase
      *
      * @var string[]
      */
-    protected $fixtures = [
+    protected array $fixtures = [
         'plugin.Avolle/CharacterPagination.Movies',
         'plugin.Avolle/CharacterPagination.Users',
     ];
@@ -32,21 +34,21 @@ class CharacterCellTest extends TestCase
      *
      * @var \Cake\Http\ServerRequest|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $request;
+    protected ServerRequest|MockObject $request;
 
     /**
      * Response mock
      *
      * @var \Cake\Http\Response|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $response;
+    protected Response|MockObject $response;
 
     /**
      * Test subject
      *
      * @var \Avolle\CharacterPagination\View\Cell\CharacterCell
      */
-    protected $Character;
+    protected CharacterCell $Character;
 
     /**
      * setUp method
@@ -111,7 +113,7 @@ class CharacterCellTest extends TestCase
     public function testDisplayRendered(): void
     {
         $this->Character->viewBuilder()->setTemplate('Avolle/CharacterPagination.display');
-        $res = (string)$this->Character->render();
+        $res = $this->Character->render();
         $expected = '<a href="/movies/index?characters=A">A</a> | <a href="/movies/index?characters=B">B</a>';
         $this->assertStringContainsString($expected, $res);
     }

--- a/tests/TestCase/View/Helper/CharacterHelperTest.php
+++ b/tests/TestCase/View/Helper/CharacterHelperTest.php
@@ -19,7 +19,7 @@ class CharacterHelperTest extends TestCase
      *
      * @var \Avolle\CharacterPagination\View\Helper\CharacterHelper
      */
-    protected $Character;
+    protected CharacterHelper $Character;
 
     /**
      * setUp method

--- a/tests/TestCase/View/Helper/CharacterHelperTest.php
+++ b/tests/TestCase/View/Helper/CharacterHelperTest.php
@@ -33,8 +33,7 @@ class CharacterHelperTest extends TestCase
         $view = new View($request);
         $this->Character = new CharacterHelper($view);
 
-        Router::reload();
-        Router::connect('/{controller}/{action}/*');
+        Router::createRouteBuilder('/')->connect('/{controller}/{action}/*');
         Router::setRequest($request);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
  */
 
 use Cake\Core\Configure;
+use Cake\Database\Connection;
+use Cake\Database\Driver\Mysql;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaLoader;
 
@@ -46,8 +48,8 @@ if (file_exists($root . '/config/bootstrap.php')) {
 
 ConnectionManager::drop('test');
 ConnectionManager::setConfig('test', [
-    'className' => \Cake\Database\Connection::class,
-    'driver' => \Cake\Database\Driver\Mysql::class,
+    'className' => Connection::class,
+    'driver' => Mysql::class,
     'host' => 'localhost',
     'database' => 'character_pagination_tests',
     'username' => 'root',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Fixture\SchemaLoader;
 
 $findRoot = function ($root) {
     do {
@@ -68,3 +69,5 @@ Configure::write('App', [
         'templates' => [dirname(APP) . DS . 'templates' . DS],
     ],
 ]);
+
+(new SchemaLoader())->loadSqlFiles($root . '/tests/schema.sql');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,8 +46,8 @@ if (file_exists($root . '/config/bootstrap.php')) {
     return;
 }
 
-ConnectionManager::drop('test');
-ConnectionManager::setConfig('test', [
+ConnectionManager::drop('default');
+ConnectionManager::setConfig('default', [
     'className' => Connection::class,
     'driver' => Mysql::class,
     'host' => 'localhost',
@@ -55,6 +55,8 @@ ConnectionManager::setConfig('test', [
     'username' => 'root',
     'password' => 'root',
 ]);
+ConnectionManager::drop('test');
+ConnectionManager::setConfig('test', ConnectionManager::get('default'));
 
 Configure::write('App', [
     'namespace' => 'TestApp',

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `movies`
+(
+    `id`      INT          NULL,
+    `title` VARCHAR(255) NULL DEFAULT NULL,
+    `link` VARCHAR(255) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `users`
+(
+    `id`      INT          NULL,
+    `name` VARCHAR(255) NULL DEFAULT NULL,
+    `email` VARCHAR(255) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -1,15 +1,15 @@
 CREATE TABLE `movies`
 (
-    `id`      INT          NULL,
+    `id`    INT NOT NULL,
     `title` VARCHAR(255) NULL DEFAULT NULL,
-    `link` VARCHAR(255) NULL DEFAULT NULL,
+    `link`  VARCHAR(255) NULL DEFAULT NULL,
     PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `users`
 (
-    `id`      INT          NULL,
-    `name` VARCHAR(255) NULL DEFAULT NULL,
+    `id`    INT NOT NULL,
+    `name`  VARCHAR(255) NULL DEFAULT NULL,
     `email` VARCHAR(255) NULL DEFAULT NULL,
     PRIMARY KEY (`id`)
 );

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp;
 
+use Avolle\CharacterPagination\Plugin as CharacterPaginationPlugin;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Middleware\RoutingMiddleware;
@@ -15,7 +16,7 @@ class Application extends BaseApplication
     public function bootstrap(): void
     {
         parent::bootstrap();
-        $this->addPlugin(\Avolle\CharacterPagination\Plugin::class);
+        $this->addPlugin(CharacterPaginationPlugin::class);
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/AppController.php
+++ b/tests/test_app/TestApp/Controller/AppController.php
@@ -23,17 +23,4 @@ use Cake\Controller\Controller;
  */
 class AppController extends Controller
 {
-    /**
-     * Initialization hook method.
-     *
-     * @return void
-     * @throws \Exception
-     */
-    public function initialize(): void
-    {
-        parent::initialize();
-
-        $this->loadComponent('RequestHandler', ['enableBeforeRedirect' => false]);
-        $this->loadComponent('Flash');
-    }
 }

--- a/tests/test_app/TestApp/Controller/AppController.php
+++ b/tests/test_app/TestApp/Controller/AppController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  * @since     0.2.9
  * @license   https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace TestApp\Controller;
 
 use Cake\Controller\Controller;

--- a/tests/test_app/TestApp/Controller/UsersController.php
+++ b/tests/test_app/TestApp/Controller/UsersController.php
@@ -16,7 +16,7 @@ class UsersController extends AppController
      *
      * @return void
      */
-    public function import()
+    public function import(): void
     {
     }
 }

--- a/tests/test_app/TestApp/Model/Entity/Movie.php
+++ b/tests/test_app/TestApp/Model/Entity/Movie.php
@@ -11,7 +11,6 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $title
  * @property string $link
- * @property \Cake\I18n\FrozenDate $release_date
  */
 class Movie extends Entity
 {
@@ -28,6 +27,5 @@ class Movie extends Entity
         'id' => false,
         'title' => true,
         'link' => true,
-        'release_date' => true,
     ];
 }

--- a/tests/test_app/TestApp/Model/Entity/Movie.php
+++ b/tests/test_app/TestApp/Model/Entity/Movie.php
@@ -21,9 +21,9 @@ class Movie extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
-    protected $_accessible = [
+    protected array $_accessible = [
         'id' => false,
         'title' => true,
         'link' => true,

--- a/tests/test_app/TestApp/Model/Entity/User.php
+++ b/tests/test_app/TestApp/Model/Entity/User.php
@@ -24,9 +24,9 @@ class User extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
-    protected $_accessible = [
+    protected array $_accessible = [
         'id' => false,
         'name' => true,
         'email' => true,

--- a/tests/test_app/TestApp/Model/Entity/User.php
+++ b/tests/test_app/TestApp/Model/Entity/User.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace TestApp\Model\Entity;
 
-use Cake\Auth\DefaultPasswordHasher;
 use Cake\ORM\Entity;
 
 /**
@@ -31,30 +30,5 @@ class User extends Entity
         'id' => false,
         'name' => true,
         'email' => true,
-        'number' => true,
-        'password' => true,
-        'role' => true,
     ];
-
-    /**
-     * Fields that are excluded from JSON versions of the entity.
-     *
-     * @var array
-     */
-    protected $_hidden = [
-        'password',
-    ];
-
-    /**
-     * Hash the user's password when entered
-     *
-     * @param string $value Password to be hashed
-     * @return false|string
-     */
-    protected function _setPassword($value)
-    {
-        $hasher = new DefaultPasswordHasher();
-
-        return $hasher->hash($value);
-    }
 }

--- a/tests/test_app/TestApp/Model/Table/MoviesTable.php
+++ b/tests/test_app/TestApp/Model/Table/MoviesTable.php
@@ -52,11 +52,6 @@ class MoviesTable extends Table
             ->scalar('title')
             ->notEmptyString('title');
 
-        $validator
-            ->requirePresence('release_date', 'create')
-            ->notEmptyDate('release_date')
-            ->date('release_date');
-
         return $validator;
     }
 }

--- a/tests/test_app/TestApp/Model/Table/UsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/UsersTable.php
@@ -62,21 +62,6 @@ class UsersTable extends Table
             ->notEmptyString('email')
             ->email('email');
 
-        $validator
-            ->requirePresence('number', 'create')
-            ->notEmptyString('number')
-            ->regex('number', '/^(\+[0-9]{1,3})?[\-0-9]{1,12}$/', __('Phone number must only contain numbers and the symbols + and -'));
-
-        $validator
-            ->requirePresence('password', 'create')
-            ->minLength('password', 4, __('Passwords must be at least 4 characters long.'))
-            ->notEmptyString('password');
-
-        $validator
-            ->requirePresence('role', 'create')
-            ->notEmptyString('role')
-            ->numeric('role', 'Invalid Role');
-
         return $validator;
     }
 

--- a/tests/test_app/TestApp/View/AppView.php
+++ b/tests/test_app/TestApp/View/AppView.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  * @since     3.0.0
  * @license   https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace TestApp\View;
 
 use Cake\View\View;

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -11,6 +11,5 @@ use Cake\Routing\RouteBuilder;
 $routes->setRouteClass(DashedRoute::class);
 
 $routes->scope('/', function (RouteBuilder $builder) {
-
     $builder->fallBacks();
 });


### PR DESCRIPTION
This PR adds support for CakePHP 5.x.

Changes, among others:
* Swap out fixture system for the new version
* Add types
* Use `SelectQuery` instead of `Query`
* Use named arguments in `find` table methods