### PR TITLE
Fix foreign characters being grouped with normal characters in list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           sudo service mysql start
           mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE character_pagination_tests;'
+          mysql -h 127.0.0.1 -u root -proot -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -86,7 +86,7 @@ class CharacterBehavior extends Behavior
     /**
      * Get the SQL ASCII value. E.g.: ASCII(name) or ASCII('Something')
      *
-     * @param \Cake\Database\Expression\FunctionExpression|string $value
+     * @param \Cake\Database\Expression\FunctionExpression|string $value Value to ASCII
      * @return \Cake\Database\Expression\FunctionExpression
      */
     protected function ascii($value): FunctionExpression
@@ -97,7 +97,7 @@ class CharacterBehavior extends Behavior
     /**
      * Get the SQL ASCII LEFT value. E.g.: ASCII(LEFT(name, 1))
      *
-     * @param \Cake\Database\Expression\IdentifierExpression $fieldIdentifier
+     * @param \Cake\Database\Expression\IdentifierExpression $fieldIdentifier Field Identifier to LEFT
      * @return \Cake\Database\Expression\FunctionExpression
      */
     protected function asciiLeft(IdentifierExpression $fieldIdentifier): FunctionExpression

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Avolle\CharacterPagination\Model\Behavior;
 
+use Cake\Database\Expression\ComparisonExpression;
+use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
@@ -54,10 +56,16 @@ class CharacterBehavior extends Behavior
         if (!isset($options['characters']) || !is_array($options['characters'])) {
             $options['characters'] = ['A'];
         }
-        $charactersString = implode('|', $options['characters']);
-        $cond = sprintf("%s REGEXP '^(%s)'", $this->determineField(), $charactersString);
+        $fieldIdentifier = new IdentifierExpression($this->determineField());
+        $field = $this->asciiLeft($fieldIdentifier);
+        $or = [];
+        foreach ($options['characters'] as $character) {
+            $asciiCond = $this->ascii($character);
+            $or[] = new ComparisonExpression($field, $asciiCond);
+        }
+        $cond = $query->newExpr()->or($or);
 
-        return $query->where($cond)->orderAsc($this->determineField());
+        return $query->where($cond)->orderAsc($fieldIdentifier);
     }
 
     /**
@@ -73,5 +81,29 @@ class CharacterBehavior extends Behavior
         }
 
         return sprintf('%s.%s', $this->table()->getAlias(), $field);
+    }
+
+    /**
+     * Get the SQL ASCII value. E.g.: ASCII(name) or ASCII('Something')
+     *
+     * @param \Cake\Database\Expression\FunctionExpression|string $value
+     * @return \Cake\Database\Expression\FunctionExpression
+     */
+    protected function ascii($value): FunctionExpression
+    {
+        return new FunctionExpression('ASCII', [$value]);
+    }
+
+    /**
+     * Get the SQL ASCII LEFT value. E.g.: ASCII(LEFT(name, 1))
+     *
+     * @param \Cake\Database\Expression\IdentifierExpression $fieldIdentifier
+     * @return \Cake\Database\Expression\FunctionExpression
+     */
+    protected function asciiLeft(IdentifierExpression $fieldIdentifier): FunctionExpression
+    {
+        $leftFunc = new FunctionExpression('LEFT', [$fieldIdentifier, 1], [1 => 'integer']);
+
+        return $this->ascii($leftFunc);
     }
 }

--- a/src/Model/Behavior/CharacterBehavior.php
+++ b/src/Model/Behavior/CharacterBehavior.php
@@ -38,7 +38,7 @@ class CharacterBehavior extends Behavior
         $firstChar = $query->func()
             ->aggregate('LEFT', [$nameIdentifier, 1], [], 'string');
 
-        return $query->select(compact('firstChar'))->group('firstChar')->orderAsc('firstChar');
+        return $query->select(compact('firstChar'))->group('ASCII(firstChar)')->orderAsc('ASCII(firstChar)');
     }
 
     /**

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -16,7 +16,7 @@ class UsersFixture extends TestFixture
     // @codingStandardsIgnoreStart
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 40, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'name' => ['type' => 'string', 'length' => 40, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
         'email' => ['type' => 'string', 'length' => 50, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
         'number' => ['type' => 'string', 'length' => 20, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
         'password' => ['type' => 'string', 'length' => 70, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
@@ -24,10 +24,6 @@ class UsersFixture extends TestFixture
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
             'email' => ['type' => 'unique', 'columns' => ['email'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'latin1_swedish_ci'
         ],
     ];
     // @codingStandardsIgnoreEnd
@@ -71,6 +67,14 @@ class UsersFixture extends TestFixture
                 'number' => '+4796666666',
                 'password' => '$2y$10$5fTuNphejvCQGth5jTIEFuWzYN646DWsSEXA6VfMitkeLVba4Dzwa', //Lorem ipsum dolor sit amet
                 'role' => 1,
+            ],
+            [
+                'id' => 5,
+                'name' => 'Å user name',
+                'email' => 'Ysome.other.other.other.user@users.com',
+                'number' => '+4797777777',
+                'password' => '$2y$10$5fTuNphejvCQGth5jTIEFuWzYN646DWsSEXA6VfMitkeLVba4Dzwa', //Lorem ipsum dolor sit amet
+                'role' => 0,
             ],
         ];
         parent::init();

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -28,7 +28,7 @@ class CharacterBehaviorTest extends TestCase
         $usersTable = new UsersTable();
         $actual = $usersTable->find('characters');
 
-        $this->assertSame(['A', 'B', 'K'], $actual->extract('firstChar')->toArray());
+        $this->assertSame(['A', 'B', 'K', 'Å'], $actual->extract('firstChar')->toArray());
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CharacterBehaviorTest.php
@@ -90,7 +90,7 @@ class CharacterBehaviorTest extends TestCase
 
     /**
      * Test findRecordsWithCharacters method
-     * `characters` option provided, and is only `A` - Get records with character `A`
+     * `characters` option provided, with various characters
      *
      * @return void
      * @uses \Avolle\CharacterPagination\Model\Behavior\CharacterBehavior::findRecordsWithCharacters()
@@ -131,6 +131,13 @@ class CharacterBehaviorTest extends TestCase
             'K User Name 4',
         ];
         $this->assertSame($expected, $actual->extract('name')->toArray());
+
+        // Foreign letter
+        $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['Å']]);
+        $expected = [
+            'Å user name',
+        ];
+        $this->assertEquals($expected, $actual->extract('name')->toArray());
 
         $actual = $usersTable->find('recordsWithCharacters', ['characters' => ['C', 'D']]);
         $this->assertEmpty($actual->extract('name')->toArray());


### PR DESCRIPTION
If you had records that start with foreign characters, they are grouped together with their regular counterpart.

For instance if you had records that start with `A` and  `Å`, just `A` was shown on the characters list. This PR fixes that bug.